### PR TITLE
Support to Scorpio, Stellio and Lepus

### DIFF
--- a/components/compose.py
+++ b/components/compose.py
@@ -91,11 +91,13 @@ class Compose:
             self.containers = [x.name for x in status if x.name in self.container_names[self.broker]]
 
             status = self.dockerEngine.container.inspect(self.containers)
-            status = [{"name": x.name, "health": x.state.health.status, "status": x.state.status} for x in status]
+            status = [{"name": x.name, "health": x.state.health.status if x.state.health is not None else "unknown", "status": x.state.status} for x in status]
 
-            health_status = [x['health'] for x in status]
-
-            if True in [ele == "unhealthy" for ele in health_status]:
+            health_status = [x['health'] if 'health' in x else "unknown" for x in status]
+            
+            if True in [ele == "unknown" for ele in health_status]:
+                res = "unknown"
+            elif True in [ele == "unhealthy" for ele in health_status]:
                 res = "unhealthy"
             elif True in [ele == "starting" for ele in health_status]:
                 res = "starting"

--- a/components/compose.py
+++ b/components/compose.py
@@ -27,16 +27,12 @@ from utils.file_utils import get_container_names_from_compose_file
 class Compose:
     def __init__(self):
         self.brokers = {
+            "Lepus": ["./composes/lepus.yml"],
             "Orion-LD": ["./composes/orionld.yml"],
             "Stellio": ["./composes/stellio.yml"],
-            "Scorpio": ["./composes/scorpio.yml"]
+            "Scorpio": ["./composes/scorpio.yml"],
         }
-
-        self.container_names = {
-            "Orion-LD": get_container_names_from_compose_file(self.brokers["Orion-LD"][0]),
-            "Stellio": get_container_names_from_compose_file(self.brokers["Stellio"][0]),
-            "Scorpio": get_container_names_from_compose_file(self.brokers["Scorpio"][0])
-        }
+        self.container_names = { broker: get_container_names_from_compose_file(self.brokers[broker][0]) for broker in self.brokers.keys() }
 
         self.dockerEngine = None
         self.broker = None

--- a/components/compose.py
+++ b/components/compose.py
@@ -21,6 +21,7 @@
 ##
 from python_on_whales import DockerClient
 from components.exceptions import ComposeInitialization, UnknownBroker, Unimplemented
+from utils.file_utils import get_container_names_from_compose_file
 
 
 class Compose:
@@ -29,6 +30,12 @@ class Compose:
             "Orion-LD": ["./composes/orionld.yml"],
             "Stellio": ["./composes/stellio.yml"],
             "Scorpio": ["./composes/scorpio.yml"]
+        }
+
+        self.container_names = {
+            "Orion-LD": get_container_names_from_compose_file(self.brokers["Orion-LD"][0]),
+            "Stellio": get_container_names_from_compose_file(self.brokers["Stellio"][0]),
+            "Scorpio": get_container_names_from_compose_file(self.brokers["Scorpio"][0])
         }
 
         self.dockerEngine = None
@@ -80,9 +87,8 @@ class Compose:
             # Error, we need to call before the initialize operation to keep the broker and create the dockerEngine
             raise ComposeInitialization(data='')
         else:
-            if len(self.containers) == 0:
-                status = self.dockerEngine.compose.ps()
-                self.containers = [x.name for x in status]
+            status = self.dockerEngine.compose.ps()
+            self.containers = [x.name for x in status if x.name in self.container_names[self.broker]]
 
             status = self.dockerEngine.container.inspect(self.containers)
             status = [{"name": x.name, "health": x.state.health.status, "status": x.state.status} for x in status]

--- a/components/compose.py
+++ b/components/compose.py
@@ -27,8 +27,8 @@ class Compose:
     def __init__(self):
         self.brokers = {
             "Orion-LD": ["./composes/orionld.yml"],
-            "Stellio": [],
-            "Scorpio": []
+            "Stellio": ["./composes/stellio.yml"],
+            "Scorpio": ["./composes/scorpio.yml"]
         }
 
         self.dockerEngine = None

--- a/components/compose.py
+++ b/components/compose.py
@@ -87,7 +87,7 @@ class Compose:
             # Error, we need to call before the initialize operation to keep the broker and create the dockerEngine
             raise ComposeInitialization(data='')
         else:
-            status = self.dockerEngine.compose.ps()
+            status = self.dockerEngine.compose.ps(all=True)
             self.containers = [x.name for x in status if x.name in self.container_names[self.broker]]
 
             status = self.dockerEngine.container.inspect(self.containers)
@@ -97,7 +97,7 @@ class Compose:
             
             if True in [ele == "unknown" for ele in health_status]:
                 res = "unknown"
-            elif True in [ele == "unhealthy" for ele in health_status]:
+            elif True in [ele == "unhealthy" for ele in health_status] or True in [ele == "exited" for ele in health_status]:
                 res = "unhealthy"
             elif True in [ele == "starting" for ele in health_status]:
                 res = "starting"

--- a/composes/config/kafka/update_run.sh
+++ b/composes/config/kafka/update_run.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# Docker workaround: Remove check for KAFKA_ZOOKEEPER_CONNECT parameter
+sed -i '/KAFKA_ZOOKEEPER_CONNECT/d' /etc/confluent/docker/configure
+
+# Docker workaround: Ignore cub zk-ready
+sed -i 's/cub zk-ready/echo ignore zk-ready/' /etc/confluent/docker/ensure
+
+# KRaft required step: Format the storage directory with a new cluster ID
+echo "kafka-storage format --ignore-formatted -t $(kafka-storage random-uuid) -c /etc/kafka/kafka.properties" >> /etc/confluent/docker/ensure

--- a/composes/lepus.yml
+++ b/composes/lepus.yml
@@ -31,7 +31,7 @@ services:
       - CONTEXT_URL=https://fiware.github.io/tutorials.Step-by-Step/tutorials-context.jsonld
       - NOTIFICATION_RELAY_URL=http://adapter:3000/notify
       
-  orion:
+  orion-v2:
     image: quay.io/fiware/orion:${LEPUS_ORION_VERSION}
     hostname: orion2
     container_name: fiware-orion-v2

--- a/composes/lepus.yml
+++ b/composes/lepus.yml
@@ -1,0 +1,57 @@
+version: '3.9'
+services:
+  mongo-for-orion-v2:
+    image: mongo:${LEPUS_MONGO_DB_VERSION}
+    hostname: mongo-db2
+    container_name: db-mongo-2
+    volumes:
+      - mongo-db2:/data
+    ports:
+      - "${LEPUS_MONGO_DB_PORT}:27017" # localhost:27017
+    networks:
+      - lepus
+    healthcheck:
+      test: |
+        host=`hostname --ip-address || echo '127.0.0.1'`; 
+        mongo --quiet $host/test --eval 'quit(db.runCommand({ ping: 1 }).ok ? 0 : 2)' && echo 0 || echo 1
+      interval: 5s
+  lepus:
+    image: quay.io/fiware/lepus
+    hostname: adapter
+    container_name: lepus
+    networks:
+      - lepus
+    expose:
+      - "${LEPUS_PORT}"
+    ports:
+      - "${LEPUS_PORT}:3000"
+    environment:
+      - DEBUG=adapter:*
+      - NGSI_V2_CONTEXT_BROKER=http://orion2:1026/v2
+      - CONTEXT_URL=https://fiware.github.io/tutorials.Step-by-Step/tutorials-context.jsonld
+      - NOTIFICATION_RELAY_URL=http://adapter:3000/notify
+      
+  orion:
+    image: quay.io/fiware/orion:${LEPUS_ORION_VERSION}
+    hostname: orion2
+    container_name: fiware-orion-v2
+    depends_on:
+      - mongo-for-orion-v2
+    networks:
+      - lepus
+    expose:
+      - "${LEPUS_ORION_PORT}"
+    ports:
+      - "${LEPUS_ORION_PORT}:1026" # localhost:1026
+    command: -dbhost mongo-db2 -logLevel DEBUG
+    healthcheck:
+      test: curl --fail -s http://orion2:1026/version || exit 1
+      interval: 5s
+
+networks:
+  lepus:
+    labels:
+      org.fiware: 'tutorial'
+
+volumes:
+  mongo-db2: ~

--- a/composes/orionld.yml
+++ b/composes/orionld.yml
@@ -12,7 +12,7 @@ services:
     depends_on:
       - mongo-db
     networks:
-      - default
+      - orion
     ports:
       - "${ORION_LD_PORT}:${ORION_LD_PORT}" # localhost:1026
     command: -dbhost mongo-db -logLevel DEBUG -forwarding  -experimental
@@ -32,7 +32,7 @@ services:
     ports:
       - "${MONGO_DB_PORT}:${MONGO_DB_PORT}" # localhost:27017
     networks:
-      - default
+      - orion
     volumes:
       - mongo-db:/data/db
       - mongo-config:/data/configdb
@@ -44,7 +44,7 @@ services:
 
 
 networks:
-  default:
+  orion:
     labels:
       org.fiware: 'tutorial'
 

--- a/composes/scorpio.yml
+++ b/composes/scorpio.yml
@@ -1,22 +1,24 @@
 version: '3'
 
 services:
-  zookeeper:
+  scorpio-zookeeper:
     image: zookeeper
+    hostname: zookeeper
     labels:
       org.nec: 'tutorial'
     networks:
-      - default
+      - scorpio
     ports:
       - "2181"
     logging:
       driver: none
-  kafka:
+  scorpio-kafka:
     image: bitnami/kafka
+    hostname: kafka
     labels:
       org.nec: 'tutorial'
     networks:
-      - default
+      - scorpio
     ports:
       - "9092"
     environment:
@@ -29,15 +31,16 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     depends_on:
-      - zookeeper
+      - scorpio-zookeeper
     logging:
       driver: none
-  postgres:
+  scorpio-postgres:
     image: postgis/postgis
+    hostname: postgres
     labels:
       org.nec: 'tutorial'
     networks:
-      - default
+      - scorpio
     ports:
       - "5432"
     environment:
@@ -50,18 +53,19 @@ services:
       - scorpio-db:/var/lib/postgresql/data
   scorpio:
     image: scorpiobroker/all-in-one-runner:ubuntu-latest
+    hostname: scorpio
     labels:
       org.nec: 'tutorial'
     networks:
-      - default
+      - scorpio
     ports:
       - "9090:9090"
     depends_on:
-      - postgres
-      - kafka
+      - scorpio-postgres
+      - scorpio-kafka
 
 networks:
-  default:
+  scorpio:
     labels:
       org.nec: 'tutorial'
 

--- a/composes/scorpio.yml
+++ b/composes/scorpio.yml
@@ -81,6 +81,9 @@ services:
     depends_on:
       - scorpio-postgres
       - scorpio-kafka
+    healthcheck:
+      test: test $(ps -ax | grep scorpio-all | wc -l) -gt 1 || exit 1
+      start_period: 30s
 
 networks:
   scorpio:

--- a/composes/scorpio.yml
+++ b/composes/scorpio.yml
@@ -70,7 +70,7 @@ services:
       start_period: 10s
   scorpio:
     container_name: scorpio
-    image: scorpiobroker/all-in-one-runner:ubuntu-latest
+    image: scorpiobroker/all-in-one-runner:${SCORPIO_VERSION}
     hostname: scorpio
     labels:
       org.nec: 'tutorial'

--- a/composes/scorpio.yml
+++ b/composes/scorpio.yml
@@ -2,6 +2,7 @@ version: '3'
 
 services:
   scorpio-zookeeper:
+    container_name: scorpio-zookeeper
     image: zookeeper
     hostname: zookeeper
     labels:
@@ -12,7 +13,11 @@ services:
       - "2181"
     logging:
       driver: none
+    healthcheck:
+      test: ["CMD-SHELL", "nc -z zookeeper 2181"]
+      interval: 5s
   scorpio-kafka:
+    container_name: scorpio-kafka
     image: bitnami/kafka
     hostname: kafka
     labels:
@@ -34,7 +39,13 @@ services:
       - scorpio-zookeeper
     logging:
       driver: none
+    healthcheck:
+      test: ["CMD-SHELL", "kafka-topics.sh --bootstrap-server localhost:9092 --list"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
   scorpio-postgres:
+    container_name: scorpio-postgres
     image: postgis/postgis
     hostname: postgres
     labels:
@@ -51,7 +62,14 @@ services:
       driver: none
     volumes:
       - scorpio-db:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -h localhost -U ngb"]
+      interval: 10s
+      timeout: 5s
+      retries: 20
+      start_period: 10s
   scorpio:
+    container_name: scorpio
     image: scorpiobroker/all-in-one-runner:ubuntu-latest
     hostname: scorpio
     labels:

--- a/composes/scorpio.yml
+++ b/composes/scorpio.yml
@@ -1,0 +1,45 @@
+version: '3'
+
+services:
+  zookeeper:
+    image: zookeeper
+    ports:
+      - "2181"
+    logging:
+      driver: none
+  kafka:
+    image: bitnami/kafka
+    ports:
+      - "9092"
+    environment:
+      KAFKA_ADVERTISED_HOST_NAME: kafka
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_ADVERTISED_PORT: 9092
+      KAFKA_LOG_RETENTION_MS: 10000
+      KAFKA_LOG_RETENTION_CHECK_INTERVAL_MS: 5000
+      ALLOW_PLAINTEXT_LISTENER: "yes"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    depends_on:
+      - zookeeper
+    logging:
+      driver: none
+  postgres:
+    image: postgis/postgis
+    ports:
+      - "5432"
+    environment:
+      POSTGRES_USER: ngb
+      POSTGRES_PASSWORD: ngb
+      POSTGRES_DB: ngb
+    logging:
+      driver: none
+#    volumes:
+#      - /custom/mount:/var/lib/postgresql/data
+  scorpio:
+    image: scorpiobroker/all-in-one-runner:ubuntu-latest
+    ports:
+      - "9090:9090"
+    depends_on:
+      - postgres
+      - kafka

--- a/composes/scorpio.yml
+++ b/composes/scorpio.yml
@@ -3,12 +3,20 @@ version: '3'
 services:
   zookeeper:
     image: zookeeper
+    labels:
+      org.nec: 'tutorial'
+    networks:
+      - default
     ports:
       - "2181"
     logging:
       driver: none
   kafka:
     image: bitnami/kafka
+    labels:
+      org.nec: 'tutorial'
+    networks:
+      - default
     ports:
       - "9092"
     environment:
@@ -26,6 +34,10 @@ services:
       driver: none
   postgres:
     image: postgis/postgis
+    labels:
+      org.nec: 'tutorial'
+    networks:
+      - default
     ports:
       - "5432"
     environment:
@@ -34,12 +46,24 @@ services:
       POSTGRES_DB: ngb
     logging:
       driver: none
-#    volumes:
-#      - /custom/mount:/var/lib/postgresql/data
+    volumes:
+      - scorpio-db:/var/lib/postgresql/data
   scorpio:
     image: scorpiobroker/all-in-one-runner:ubuntu-latest
+    labels:
+      org.nec: 'tutorial'
+    networks:
+      - default
     ports:
       - "9090:9090"
     depends_on:
       - postgres
       - kafka
+
+networks:
+  default:
+    labels:
+      org.nec: 'tutorial'
+
+volumes:
+  scorpio-db: ~

--- a/composes/stellio.yml
+++ b/composes/stellio.yml
@@ -1,0 +1,94 @@
+version: '3.9'
+services:
+  kafka:
+    image: confluentinc/cp-kafka:7.3.1
+    container_name: stellio-kafka
+    hostname: stellio-kafka
+    ports:
+      - "29092:29092"
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://stellio-kafka:9092,PLAINTEXT_HOST://localhost:29092
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_PROCESS_ROLES: 'broker,controller'
+      KAFKA_NODE_ID: 1
+      KAFKA_CONTROLLER_QUORUM_VOTERS: '1@stellio-kafka:29093'
+      KAFKA_LISTENERS: CONTROLLER://stellio-kafka:29093,PLAINTEXT://stellio-kafka:9092,PLAINTEXT_HOST://0.0.0.0:29092
+      KAFKA_INTER_BROKER_LISTENER_NAME: 'PLAINTEXT'
+      KAFKA_CONTROLLER_LISTENER_NAMES: 'CONTROLLER'
+      KAFKA_LOG4J_ROOT_LOGLEVEL: INFO
+    volumes:
+      - ./config/kafka/update_run.sh:/tmp/update_run.sh
+    command: "bash -c 'if [ ! -f /tmp/update_run.sh ]; then echo \"ERROR: Did you forget the update_run.sh file that came with this docker-compose.yml file?\" && exit 1 ; else /tmp/update_run.sh && /etc/confluent/docker/run ; fi'"
+  postgres:
+    image: stellio/stellio-timescale-postgis:14-2.11.1-3.3
+    container_name: stellio-postgres
+    environment:
+      - POSTGRES_USER=${POSTGRES_USER}
+      - POSTGRES_PASS=${POSTGRES_PASS}
+      - POSTGRES_DBNAME=${POSTGRES_DBNAME}
+      - POSTGRES_MULTIPLE_EXTENSIONS=postgis,timescaledb,pgcrypto
+      - ACCEPT_TIMESCALE_TUNING=TRUE
+    ports:
+      - "5432:5432"
+    volumes:
+      - stellio-postgres-storage:/var/lib/postgresql
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -h localhost -U stellio"]
+      interval: 10s
+      timeout: 5s
+      retries: 20
+      start_period: 10s
+  api-gateway:
+    container_name: stellio-api-gateway
+    image: stellio/stellio-api-gateway:${STELLIO_DOCKER_TAG}
+    environment:
+      - SPRING_PROFILES_ACTIVE=${ENVIRONMENT}
+    ports:
+      - "8080:8080"
+  search-service:
+    container_name: stellio-search-service
+    image: stellio/stellio-search-service:${STELLIO_DOCKER_TAG}
+    environment:
+      - SPRING_PROFILES_ACTIVE=${ENVIRONMENT}
+      - SPRING_R2DBC_URL=r2dbc:postgresql://postgres/${STELLIO_SEARCH_DB_DATABASE}
+      - SPRING_FLYWAY_URL=jdbc:postgresql://postgres/${STELLIO_SEARCH_DB_DATABASE}
+      - SPRING_R2DBC_USERNAME=${POSTGRES_USER}
+      - SPRING_R2DBC_PASSWORD=${POSTGRES_PASS}
+      - APPLICATION_AUTHENTICATION_ENABLED=${STELLIO_AUTHENTICATION_ENABLED}
+      - APPLICATION_TENANTS_0_ISSUER=${APPLICATION_TENANTS_0_ISSUER}
+      - APPLICATION_TENANTS_0_URI=${APPLICATION_TENANTS_0_URI}
+      - APPLICATION_TENANTS_0_DBSCHEMA=${APPLICATION_TENANTS_0_DBSCHEMA}
+    ports:
+      - "8083:8083"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      kafka:
+        condition: service_started
+  subscription-service:
+    container_name: stellio-subscription-service
+    image: stellio/stellio-subscription-service:${STELLIO_DOCKER_TAG}
+    environment:
+      - SPRING_PROFILES_ACTIVE=${ENVIRONMENT}
+      - SPRING_R2DBC_URL=r2dbc:postgresql://postgres/${STELLIO_SUBSCRIPTION_DB_DATABASE}
+      - SPRING_FLYWAY_URL=jdbc:postgresql://postgres/${STELLIO_SUBSCRIPTION_DB_DATABASE}
+      - SPRING_R2DBC_USERNAME=${POSTGRES_USER}
+      - SPRING_R2DBC_PASSWORD=${POSTGRES_PASS}
+      - APPLICATION_AUTHENTICATION_ENABLED=${STELLIO_AUTHENTICATION_ENABLED}
+      - APPLICATION_TENANTS_0_ISSUER=${APPLICATION_TENANTS_0_ISSUER}
+      - APPLICATION_TENANTS_0_URI=${APPLICATION_TENANTS_0_URI}
+      - APPLICATION_TENANTS_0_DBSCHEMA=${APPLICATION_TENANTS_0_DBSCHEMA}
+      - SUBSCRIPTION_ENTITY_SERVICE-URL=${SUBSCRIPTION_ENTITY_SERVICE_URL}
+      - SUBSCRIPTION_STELLIO_URL=${SUBSCRIPTION_STELLIO_URL}
+    ports:
+      - "8084:8084"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      kafka:
+        condition: service_started
+
+volumes:
+  stellio-postgres-storage:

--- a/composes/stellio.yml
+++ b/composes/stellio.yml
@@ -61,6 +61,9 @@ services:
       - stellio
     ports:
       - "8080:8080"
+    healthcheck:
+      test: curl --fail -X OPTIONS -s localhost:8080/ngsi-ld/v1/entities/ || exit 1
+      start_period: 30s
   stellio-search-service:
     container_name: stellio-search-service
     image: stellio/stellio-search-service:${STELLIO_DOCKER_TAG}
@@ -84,6 +87,9 @@ services:
         condition: service_healthy
       stellio-kafka:
         condition: service_started
+    healthcheck:
+      test: curl --fail -X OPTIONS -s stellio-api-gateway:8080/ngsi-ld/v1/entities/ || exit 1
+      start_period: 30s
   stellio-subscription-service:
     container_name: stellio-subscription-service
     image: stellio/stellio-subscription-service:${STELLIO_DOCKER_TAG}
@@ -109,6 +115,9 @@ services:
         condition: service_healthy
       stellio-kafka:
         condition: service_started
+    healthcheck:
+      test: curl --fail -X OPTIONS -s stellio-api-gateway:8080/ngsi-ld/v1/entities/ || exit 1
+      start_period: 30s
 
 networks:
   stellio:

--- a/composes/stellio.yml
+++ b/composes/stellio.yml
@@ -1,15 +1,9 @@
 version: '3.9'
 services:
-  kafka:
+  stellio-kafka:
     image: confluentinc/cp-kafka:7.3.1
-    labels:
-      org.egm: 'tutorial'
-    networks:
-      - default
     container_name: stellio-kafka
-    hostname: stellio-kafka
-    ports:
-      - "29092:29092"
+    hostname: kafka
     environment:
       KAFKA_BROKER_ID: 1
       KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
@@ -22,22 +16,25 @@ services:
       KAFKA_INTER_BROKER_LISTENER_NAME: 'PLAINTEXT'
       KAFKA_CONTROLLER_LISTENER_NAMES: 'CONTROLLER'
       KAFKA_LOG4J_ROOT_LOGLEVEL: INFO
+    networks:
+      - stellio
+    ports:
+      - "29092:29092"
     volumes:
       - ./config/kafka/update_run.sh:/tmp/update_run.sh
     command: "bash -c 'if [ ! -f /tmp/update_run.sh ]; then echo \"ERROR: Did you forget the update_run.sh file that came with this docker-compose.yml file?\" && exit 1 ; else /tmp/update_run.sh && /etc/confluent/docker/run ; fi'"
-  postgres:
+  stellio-postgres:
     image: stellio/stellio-timescale-postgis:14-2.11.1-3.3
-    labels:
-      org.egm: 'tutorial'
-    networks:
-      - default
     container_name: stellio-postgres
+    hostname: postgres
     environment:
       - POSTGRES_USER=${POSTGRES_USER}
       - POSTGRES_PASS=${POSTGRES_PASS}
       - POSTGRES_DBNAME=${POSTGRES_DBNAME}
       - POSTGRES_MULTIPLE_EXTENSIONS=postgis,timescaledb,pgcrypto
       - ACCEPT_TIMESCALE_TUNING=TRUE
+    networks:
+      - stellio
     ports:
       - "5432:5432"
     volumes:
@@ -48,24 +45,20 @@ services:
       timeout: 5s
       retries: 20
       start_period: 10s
-  api-gateway:
+  stellio-api-gateway:
     container_name: stellio-api-gateway
     image: stellio/stellio-api-gateway:${STELLIO_DOCKER_TAG}
-    labels:
-      org.egm: 'tutorial'
-    networks:
-      - default
+    hostname: api-gateway
     environment:
       - SPRING_PROFILES_ACTIVE=${ENVIRONMENT}
+    networks:
+      - stellio
     ports:
       - "8080:8080"
-  search-service:
+  stellio-search-service:
     container_name: stellio-search-service
     image: stellio/stellio-search-service:${STELLIO_DOCKER_TAG}
-    labels:
-      org.egm: 'tutorial'
-    networks:
-      - default
+    hostname: search-service
     environment:
       - SPRING_PROFILES_ACTIVE=${ENVIRONMENT}
       - SPRING_R2DBC_URL=r2dbc:postgresql://postgres/${STELLIO_SEARCH_DB_DATABASE}
@@ -76,20 +69,19 @@ services:
       - APPLICATION_TENANTS_0_ISSUER=${APPLICATION_TENANTS_0_ISSUER}
       - APPLICATION_TENANTS_0_URI=${APPLICATION_TENANTS_0_URI}
       - APPLICATION_TENANTS_0_DBSCHEMA=${APPLICATION_TENANTS_0_DBSCHEMA}
+    networks:
+      - stellio
     ports:
       - "8083:8083"
     depends_on:
-      postgres:
+      stellio-postgres:
         condition: service_healthy
-      kafka:
+      stellio-kafka:
         condition: service_started
-  subscription-service:
+  stellio-subscription-service:
     container_name: stellio-subscription-service
     image: stellio/stellio-subscription-service:${STELLIO_DOCKER_TAG}
-    labels:
-      org.egm: 'tutorial'
-    networks:
-      - default
+    hostname: subscription-service
     environment:
       - SPRING_PROFILES_ACTIVE=${ENVIRONMENT}
       - SPRING_R2DBC_URL=r2dbc:postgresql://postgres/${STELLIO_SUBSCRIPTION_DB_DATABASE}
@@ -102,16 +94,18 @@ services:
       - APPLICATION_TENANTS_0_DBSCHEMA=${APPLICATION_TENANTS_0_DBSCHEMA}
       - SUBSCRIPTION_ENTITY_SERVICE-URL=${SUBSCRIPTION_ENTITY_SERVICE_URL}
       - SUBSCRIPTION_STELLIO_URL=${SUBSCRIPTION_STELLIO_URL}
+    networks:
+      - stellio
     ports:
       - "8084:8084"
     depends_on:
-      postgres:
+      stellio-postgres:
         condition: service_healthy
-      kafka:
+      stellio-kafka:
         condition: service_started
 
 networks:
-  default:
+  stellio:
     labels:
       org.egm: 'tutorial'
 

--- a/composes/stellio.yml
+++ b/composes/stellio.yml
@@ -24,7 +24,8 @@ services:
       - ./config/kafka/update_run.sh:/tmp/update_run.sh
     command: "bash -c 'if [ ! -f /tmp/update_run.sh ]; then echo \"ERROR: Did you forget the update_run.sh file that came with this docker-compose.yml file?\" && exit 1 ; else /tmp/update_run.sh && /etc/confluent/docker/run ; fi'"
     healthcheck:
-      test: ["CMD-SHELL", "kafka-topics.sh --bootstrap-server localhost:9092 --list"]
+      test: nc -z localhost 29092 || exit -1
+      start_period: 15s
       interval: 30s
       timeout: 10s
       retries: 3

--- a/composes/stellio.yml
+++ b/composes/stellio.yml
@@ -23,6 +23,11 @@ services:
     volumes:
       - ./config/kafka/update_run.sh:/tmp/update_run.sh
     command: "bash -c 'if [ ! -f /tmp/update_run.sh ]; then echo \"ERROR: Did you forget the update_run.sh file that came with this docker-compose.yml file?\" && exit 1 ; else /tmp/update_run.sh && /etc/confluent/docker/run ; fi'"
+    healthcheck:
+      test: ["CMD-SHELL", "kafka-topics.sh --bootstrap-server localhost:9092 --list"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
   stellio-postgres:
     image: stellio/stellio-timescale-postgis:14-2.11.1-3.3
     container_name: stellio-postgres

--- a/composes/stellio.yml
+++ b/composes/stellio.yml
@@ -2,6 +2,10 @@ version: '3.9'
 services:
   kafka:
     image: confluentinc/cp-kafka:7.3.1
+    labels:
+      org.egm: 'tutorial'
+    networks:
+      - default
     container_name: stellio-kafka
     hostname: stellio-kafka
     ports:
@@ -23,6 +27,10 @@ services:
     command: "bash -c 'if [ ! -f /tmp/update_run.sh ]; then echo \"ERROR: Did you forget the update_run.sh file that came with this docker-compose.yml file?\" && exit 1 ; else /tmp/update_run.sh && /etc/confluent/docker/run ; fi'"
   postgres:
     image: stellio/stellio-timescale-postgis:14-2.11.1-3.3
+    labels:
+      org.egm: 'tutorial'
+    networks:
+      - default
     container_name: stellio-postgres
     environment:
       - POSTGRES_USER=${POSTGRES_USER}
@@ -43,6 +51,10 @@ services:
   api-gateway:
     container_name: stellio-api-gateway
     image: stellio/stellio-api-gateway:${STELLIO_DOCKER_TAG}
+    labels:
+      org.egm: 'tutorial'
+    networks:
+      - default
     environment:
       - SPRING_PROFILES_ACTIVE=${ENVIRONMENT}
     ports:
@@ -50,6 +62,10 @@ services:
   search-service:
     container_name: stellio-search-service
     image: stellio/stellio-search-service:${STELLIO_DOCKER_TAG}
+    labels:
+      org.egm: 'tutorial'
+    networks:
+      - default
     environment:
       - SPRING_PROFILES_ACTIVE=${ENVIRONMENT}
       - SPRING_R2DBC_URL=r2dbc:postgresql://postgres/${STELLIO_SEARCH_DB_DATABASE}
@@ -70,6 +86,10 @@ services:
   subscription-service:
     container_name: stellio-subscription-service
     image: stellio/stellio-subscription-service:${STELLIO_DOCKER_TAG}
+    labels:
+      org.egm: 'tutorial'
+    networks:
+      - default
     environment:
       - SPRING_PROFILES_ACTIVE=${ENVIRONMENT}
       - SPRING_R2DBC_URL=r2dbc:postgresql://postgres/${STELLIO_SUBSCRIPTION_DB_DATABASE}
@@ -90,5 +110,10 @@ services:
       kafka:
         condition: service_started
 
+networks:
+  default:
+    labels:
+      org.egm: 'tutorial'
+
 volumes:
-  stellio-postgres-storage:
+  stellio-postgres-storage: ~

--- a/utils/file_utils.py
+++ b/utils/file_utils.py
@@ -1,0 +1,5 @@
+def get_container_names_from_compose_file(file_path):
+    with open(file_path, 'r') as file:
+        data = file.readlines()
+    # return only the lines that contains "container_name", clean the result of any space or \n
+    return [x.split("container_name:")[-1].strip() for x in data if "container_name" in x]


### PR DESCRIPTION
I've implemented the support to Scorpio and Stellio by doing the following things:
- added the docker-compose files and the config file for the kafka container (required for the kafka container of stellio)
- updated the compose.py file with the path of the docker-compose files

Also, the /check_status was returning the healthcheck of orionld's containers. Now, /check_status works with Scorpio and Stellio as well. For each broker, the Compose class keeps also the container names that were found in the compose files. To do this, the docker-compose files must have the "container_name" parameter for each service defined as it is required to scrap this information out of the docker-compose files. Then it is able to filter the right containers returned from the "docker ps"  command and it replies to the client with the containers of the given broker (if they are alive).

I've introduced the concept of "unknown" status, when the healthcheck for a container is not defined in the docker-compose file.

Finally, as I said, I've imported the docker-compose files for Scorpio and Stellio, but I want to highlight that I've made a few changes:
- I've added custom networks (for orionld.yml as well)
- I've changed the name of the services prefixing the broker's name
- I've added healthchecks where it was possible